### PR TITLE
feat: fastapi_jwt_auth, pydantic downgrade, image s3 upload

### DIFF
--- a/app/schemas/profile.py
+++ b/app/schemas/profile.py
@@ -35,8 +35,8 @@ class UserProfileResponse(BaseModel):
     past_weight: int
     weight_change: int = Field(..., description="체중 변화량")
     age: str = Field(..., example="1년 2개월")    
-    # health_history: List[str] = Field(..., description="질병 이력 목록")
-    # vaccinations: List[str] = Field(..., description="백신 접종 이력 목록")
+    health_history: List[str] = Field(..., description="질병 이력 목록")
+    vaccinations: List[str] = Field(..., description="백신 접종 이력 목록")
     
     class Config:
         from_attributes = True
@@ -68,19 +68,15 @@ class UserProfileAbstract(BaseModel):
     # 방문자 리스트 -> 방문자 수
     # 한 줄 소개
 
-class ProfileViewBase(BaseModel):
+class ProfileViewCreate(BaseModel):
     owner_id: int
     visitor_id: int
-    viewed_at: datetime
-
-    class Config:
-        from_attributes = True
 
 # <방문자 기록> 화면에서 보여줄 내용들
 class ProfileViewer(BaseModel):
     visitor_id: int     # 방문자 고유 ID -> 이를 통해 해당 방문자의 프로필(피드)로 이동할 수 있도록
     visitor_name: str   # 방문자 이름
-    # visitor_image : None # 방문자의 프로필 이미지
+    visitor_image : str # 방문자의 프로필 이미지
     viewed_at : datetime # 정렬을 위해?
 
 

--- a/app/services/image.py
+++ b/app/services/image.py
@@ -1,0 +1,50 @@
+"""
+이미지 처리와 관련된 유틸 함수
+"""
+import base64
+import io
+import os
+import uuid
+import boto3
+from fastapi import HTTPException
+from dotenv import load_dotenv
+load_dotenv()
+
+def create_s3_client():
+    """S3 클라이언트 생성"""
+    return boto3.client(
+        's3',
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
+        region_name='ap-northeast-2'
+    )
+
+def upload_image_to_s3(base64_string: str, s3_client) -> str:
+    """
+    Base64 이미지를 S3에 업로드하고 URL 반환
+    """
+    try:
+        bucket_name = 'balm-bucket'
+
+        # base64 디코딩
+        if 'base64,' in base64_string:
+            image_data = base64_string.split('base64,')[1]
+        else:
+            image_data = base64_string
+        image_bytes = base64.b64decode(image_data)
+        # S3에 업로드
+        file_id = str(uuid.uuid4())
+        key = f"images/user/{file_id}.jpg"
+        s3_client.upload_fileobj(
+            io.BytesIO(image_bytes),
+            bucket_name,
+            key,
+            ExtraArgs={
+                'ContentType': 'image/jpeg',
+                'CacheControl': 'max-age=31536000'
+            }
+        )
+        return f"https://{bucket_name}.s3.ap-northeast-2.amazonaws.com/{key}"
+    
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to upload image: {str(e)}") from e

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -1,17 +1,29 @@
 from sqlalchemy.orm import Session
-from sqlalchemy import func
-from ..models.onboarding import Disease, DogBreeds, Vaccinations, Allergies 
 from dotenv import load_dotenv
+from ..models.onboarding import Disease as DiseaseTable
+from ..models.onboarding import DogBreeds as DogBreedsTable
+from ..models.onboarding import Vaccinations as VaccinationsTable
+from ..models.onboarding import Allergies as AllergiesTable 
+from ..schemas.onboarding import Disease, DogBreed, Vaccination, Allergy
+
 load_dotenv()
 
 # 질병 리스트 반환
 def get_disease_list(db : Session):
-    diseases = db.query(Disease).all()
-    return diseases
+    diseases = db.query(DiseaseTable).all()
+    data = []
+    for disease in diseases:
+        data.append(
+            Disease(
+                id = disease.id,
+                name = disease.name
+            )
+        )
+    return data
 
 # 질병 등록
 def create_disease(db : Session, name : str):
-    disease = Disease(name=name)
+    disease = DiseaseTable(name=name)
     db.add(disease)
     db.commit()
     db.refresh(disease)
@@ -19,7 +31,7 @@ def create_disease(db : Session, name : str):
 
 # 질병 ID로 삭제
 def delete_disease_by_id(db: Session, disease_id: int) -> bool:
-    disease = db.query(Disease).filter(Disease.id == disease_id).first()
+    disease = db.query(DiseaseTable).filter(DiseaseTable.id == disease_id).first()
     if disease:
         db.delete(disease)
         db.commit()
@@ -28,12 +40,20 @@ def delete_disease_by_id(db: Session, disease_id: int) -> bool:
 
 # 강아지 품종 리스트 반환
 def get_dogbreed_list(db : Session):
-    dogbreeds = db.query(DogBreeds).all()
-    return dogbreeds
+    dogbreeds = db.query(DogBreedsTable).all()
+    data = []
+    for dogbreed in dogbreeds:
+        data.append(
+            DogBreed(
+                id = dogbreed.id,
+                name = dogbreed.name
+            )
+        )
+    return data
 
 # 강아지 품종 등록
 def create_dogbreed(db : Session, name : str):
-    dog_breed = DogBreeds(name=name)
+    dog_breed = DogBreedsTable(name=name)
     db.add(dog_breed)
     db.commit()
     db.refresh(dog_breed)
@@ -41,7 +61,7 @@ def create_dogbreed(db : Session, name : str):
 
 # 강아지 품종 ID로 삭제
 def delete_dogbreed_by_id(db: Session, dogbreed_id: int) -> bool:
-    dogbreed = db.query(DogBreeds).filter(DogBreeds.id == dogbreed_id).first()
+    dogbreed = db.query(DogBreedsTable).filter(DogBreedsTable.id == dogbreed_id).first()
     if dogbreed:
         db.delete(dogbreed)
         db.commit()
@@ -50,12 +70,20 @@ def delete_dogbreed_by_id(db: Session, dogbreed_id: int) -> bool:
 
 # 백신 리스트 반환
 def get_vaccination_list(db : Session):
-    vaccinations = db.query(Vaccinations).all()
-    return vaccinations
+    vaccinations = db.query(VaccinationsTable).all()
+    data = []
+    for vaccination in vaccinations:
+        data.append(
+            Vaccination(
+                id = vaccination.id,
+                name = vaccination.name
+            )
+        )
+    return data
 
 # 백신 등록
 def create_vaccination(db : Session, name : str):
-    vaccination = Vaccinations(name=name)
+    vaccination = VaccinationsTable(name=name)
     db.add(vaccination)
     db.commit()
     db.refresh(vaccination)
@@ -63,7 +91,7 @@ def create_vaccination(db : Session, name : str):
 
 # 백신 삭제
 def delete_vaccination_by_id(db: Session, vaccination_id: int) -> bool:
-    vaccination = db.query(Vaccinations).filter(Vaccinations.id == vaccination_id).first()
+    vaccination = db.query(VaccinationsTable).filter(VaccinationsTable.id == vaccination_id).first()
     if vaccination:
         db.delete(vaccination)
         db.commit()
@@ -72,12 +100,20 @@ def delete_vaccination_by_id(db: Session, vaccination_id: int) -> bool:
 
 # 백신 리스트 반환
 def get_allergy_list(db : Session):
-    allergies = db.query(Allergies).all()
-    return allergies
+    allergies = db.query(AllergiesTable).all()
+    data = []
+    for allergy in allergies:
+        data.append(
+            Allergy(
+                id = allergy.id,
+                name = allergy.name
+            )
+        )
+    return data
 
 # 알러지 등록
 def create_allergy(db : Session, name : str):
-    allergy = Allergies(name=name)
+    allergy = AllergiesTable(name=name)
     db.add(allergy)
     db.commit()
     db.refresh(allergy)
@@ -85,7 +121,7 @@ def create_allergy(db : Session, name : str):
 
 # 알러지 삭제
 def delete_allergy_by_id(db: Session, allergy_id: int) -> bool:
-    allergy = db.query(DogBreeds).filter(DogBreeds.id == allergy_id).first()
+    allergy = db.query(DogBreedsTable).filter(DogBreedsTable.id == allergy_id).first()
     if allergy:
         db.delete(allergy)
         db.commit()

--- a/app/services/profile.py
+++ b/app/services/profile.py
@@ -1,41 +1,63 @@
 from sqlalchemy.orm import Session
 from fastapi import HTTPException
-from sqlalchemy import func
 from dotenv import load_dotenv
 from ..schemas.profile import UserProfileCreate, UserProfileResponse, UserProfileUpdate
 from ..schemas.login import UserCreate
-from ..schemas.profile import ProfileViewBase, ProfileViewer
+from ..schemas.login import User as UserList
+from ..schemas.profile import ProfileViewCreate, ProfileViewer
 from ..models.profile import UserProfile, ProfileView
 from ..models.login import User
 from ..models.onboarding import DogBreeds
+from ..services.image import create_s3_client, upload_image_to_s3
 from dateutil.relativedelta import relativedelta
 from datetime import datetime
 load_dotenv()
 
 def create_user_profile(db: Session, user: UserCreate, profile: UserProfileCreate):
-    db_profile = UserProfile(
-        social_id=user.social_id,
-        dog_name=profile.dog_name,
-        dog_gender=profile.dog_gender,
-        dog_size=profile.dog_size,
-        dog_breed=profile.dog_breed,
-        dog_cuteness=profile.dog_cuteness,
-        photo_path=profile.photo_path,
-        birth_day=profile.birth_day,
-        current_weight=profile.current_weight,
-        past_weight=profile.past_weight,
-        health_history=profile.health_history,
-        vaccinations=profile.vaccinations
-    )
-    db.add(db_profile)
-    db.commit()
-    db.refresh(db_profile)
-    return db_profile
+    try:
+        # base64 이미지를 S3에 업로드
+        s3_url = ""
+        if profile.photo_path != "":
+            base64_image = profile.photo_path
+            s3_client = create_s3_client()
+            s3_url = upload_image_to_s3(base64_image, s3_client)
+        db_profile = UserProfile(
+            social_id=user.social_id,
+            dog_name=profile.dog_name,
+            dog_gender=profile.dog_gender,
+            dog_size=profile.dog_size,
+            dog_breed=profile.dog_breed,
+            dog_cuteness=profile.dog_cuteness,
+            photo_path=s3_url,
+            birth_day=profile.birth_day,
+            current_weight=profile.current_weight,
+            past_weight=profile.past_weight,
+            health_history=profile.health_history,
+            vaccinations=profile.vaccinations
+        )
+        db.add(db_profile)
+        db.commit()
+        db.refresh(db_profile)
+        return db_profile
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
 
 # 모든 사용자들의 ID를 반환
 def get_users(db:Session):
     users = db.query(User).all()
-    return users
+    data = []
+    for user in users:
+        data.append(
+            UserList(
+                id = user.id,
+                social_id= user.social_id,
+                name = user.name,
+                is_active= user.is_active
+            )
+        )
+    return data
 
 def get_user_by_id(db:Session, user_id:int):
     user = db.query(User).filter(User.id == user_id).first()
@@ -73,9 +95,10 @@ def get_user_profile(db: Session, user_id: int):
         past_weight=profile.past_weight,
         weight_change=profile.current_weight-profile.past_weight,
         age=f"{diff.months}개월" if diff.years == 0 else f"{diff.years}년 {diff.months}개월",
-        # health_history=profile.health_history,
-        # vaccinations=profile.vaccinations
+        health_history= [x.strip() for x in profile.health_history.split(',')],
+        vaccinations=[x.strip() for x in profile.vaccinations.split(',')]
     )
+
     return profile_response
 
 # 특정 사용자의 프로필 수정(일부 수정 가능)
@@ -103,29 +126,34 @@ def update_user_profile(db: Session, user_id: int, profile_update: UserProfileUp
     # 업데이트된 프로필 반환
     return get_user_profile(db, user_id) # 수정된 사항 확인할 수 있도록
 
-def create_view(db: Session, view:ProfileViewBase):
-    db_view = ProfileView(**view.dict())
+def create_view(db: Session, view:ProfileViewCreate):
+    db_view = ProfileView(
+        owner_id=view.owner_id,
+        visitor_id=view.visitor_id
+    )
     db.add(db_view)
     db.commit()
     db.refresh(db_view)
-    return db_view
 
-def get_visitor_lists(db: Session, user_id : int):
+    return view
+
+def get_visitor_lists(db: Session, user_id: int):
     results = (
         db.query(
             ProfileView.visitor_id,
             User.name.label('visitor_name'),
-            # User.image.label('visitor_image'), # 나중에 유저 프로필 사진 등록시 같이 추가할 예정
+            UserProfile.photo_path.label('visitor_image'),  # UserProfile의 photo_path 사용
             ProfileView.viewed_at
         )
         .join(User, User.id == ProfileView.visitor_id)
+        .join(UserProfile, User.social_id == UserProfile.social_id)  # UserProfile 조인 추가
         .filter(ProfileView.owner_id == user_id)
         .order_by( 
-            ProfileView.visitor_id,             # visitor_id로 그룹핑
-            ProfileView.viewed_at.desc()        # 같은 visitor_id 내에서 최신순 정렬
+            ProfileView.visitor_id,            
+            ProfileView.viewed_at.desc()        
         )
-        .distinct(ProfileView.visitor_id)       # visitor_id 별로 최신 조회 기록만 선택
-        .order_by(ProfileView.viewed_at.desc()) # 최종 결과를 다시 최신순 정렬
+        .distinct(ProfileView.visitor_id)      
+        .order_by(ProfileView.viewed_at.desc())
         .all()
     )
 
@@ -133,7 +161,7 @@ def get_visitor_lists(db: Session, user_id : int):
         ProfileViewer(
             visitor_id=row.visitor_id,
             visitor_name=row.visitor_name,
-            # visitor_image=row.visitor_image,
+            visitor_image=row.visitor_image,
             viewed_at=row.viewed_at
         )
         for row in results

--- a/main.py
+++ b/main.py
@@ -9,6 +9,25 @@ from starlette_context.middleware import ContextMiddleware
 from starlette.responses import Response, JSONResponse
 from app.routers import login, onboarding, profile, admin
 from app.database.db import db_manager
+from fastapi_jwt_auth import AuthJWT
+from pydantic import BaseModel
+import os
+from datetime import timedelta
+
+class Settings(BaseModel):
+    """
+    AuthJWT config setting
+    """
+    authjwt_secret_key: str = os.getenv("JWT_SECRET_KEY", "test_token")
+    authjwt_access_token_expires: int = timedelta(days=1)       # access_token은 1일
+    authjwt_refresh_token_expires: int = timedelta(days=3)      # 3일
+
+@AuthJWT.load_config
+def get_config():
+    """
+    AuthJWT config
+    """
+    return Settings()
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ anyio==4.6.0
 astroid==3.3.5
 asyncpg==0.29.0
 bcrypt==4.2.0
+boto3==1.35.66
+botocore==1.35.66
 certifi==2024.8.30
 cffi==1.17.1
 click==8.1.7
@@ -12,6 +14,7 @@ cryptography==43.0.1
 dill==0.3.9
 distlib==0.3.9
 fastapi==0.115.2
+fastapi-jwt-auth==0.5.0
 filelock==3.16.1
 greenlet==3.1.1
 h11==0.14.0
@@ -20,6 +23,7 @@ httptools==0.6.1
 httpx==0.27.2
 idna==3.10
 isort==5.13.2
+jmespath==1.0.1
 Mako==1.3.5
 MarkupSafe==3.0.1
 mccabe==0.7.0
@@ -27,14 +31,15 @@ paramiko==3.5.0
 platformdirs==4.3.6
 psycopg2-binary==2.9.9
 pycparser==2.22
-pydantic==2.9.2
+pydantic==1.10.13
 pydantic_core==2.23.4
-PyJWT==2.9.0
+PyJWT==1.7.1
 pylint==3.3.1
 PyNaCl==1.5.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 PyYAML==6.0.2
+s3transfer==0.10.4
 six==1.16.0
 sniffio==1.3.1
 SQLAlchemy==2.0.35
@@ -44,6 +49,7 @@ starlette==0.39.2
 starlette-context==0.3.6
 tomlkit==0.13.2
 typing_extensions==4.12.2
+urllib3==2.2.3
 uvicorn==0.31.1
 watchfiles==0.24.0
 websockets==13.1


### PR DESCRIPTION
하나 바꾸기 시작하니깐 의존된 것들을 연달아 바꾸다 보니 기능별로 branch를 나눠서 pr을 날리지 못했슴다...죄송합니다

### requirements 변경 사항
- 기존의 JWT token 만들던 방식과 fast_jwt_auth의 방식이 달라서 호환되지 않음
- fast_jwt_auth로 바꾸려고 하니 기존 pydantic은 V2인데 fast_jwt_auth가 V2에서 호환이 되지 않음
- feed쪽이 우선 fast_jwt_auth를 이용해서 구현되었기에 pydantic을 V1으로 다운그레이드
- s3 연결을 위해 boto3 추가 설치

### pydantic version downgrade에 따른 service 코드 수정
- 기존의 코드가 DB에서 긁은 것 그대로 반환하는 구조
- pydantic V2에서는 알아서 json으로 처리가 되는 구조
- pydantic V1에서는 안 되어서 Schema에 맞게 직접 변환해서 반환하도록 수정

### ProfileResponse 수정
- 질병 이력, 백신 접종 이력이 유저 생성 시 ','로 구분된 하나의 string으로 입력되어 저장되는 구조
- 기존에는 개발 편의상 이에 대한 Response를 생략
- 저장된 String에 대해 ','로 분리하고 리스트 형태로 반환하도록 추가

### 프로필 이미지 S3 연동
- signup과정에서 photo_path에 base64 str이 들어오면 s3에 업로드하고 URL을 반환
- photo_path가 안 들어오면 빈 스트링으로 처리

### 방문자 리스트 조회 API 수정
- 방문자의 이미지를 추가하는 부분 추가