### PR TITLE
Fix: change user_id to social_id

### DIFF
--- a/app/database/db.py
+++ b/app/database/db.py
@@ -49,6 +49,12 @@ class DatabaseManager:
             print("Database created!")
         else:
             print("Database already exists.")
+            # table = self.Base.metadata.tables.get("profile_views")
+            # if table is not None:
+            #     table.drop(self.engine)
+            #     # 테이블 다시 생성
+            #     table.create(self.engine)
+            #     print("Recreate!")
         self.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
         
     def cleanup(self):

--- a/app/models/profile.py
+++ b/app/models/profile.py
@@ -26,8 +26,8 @@ class UserProfile(Base):
 class ProfileView(Base):
     __tablename__ = "profile_views"
     id = Column(Integer, primary_key=True, index=True)
-    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    visitor_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    owner_id = Column(String, ForeignKey("users.social_id"), nullable=False)
+    visitor_id = Column(String, ForeignKey("users.social_id"), nullable=False)
     viewed_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     # 같은 User 테이블을 여러 foreign key로 참조하므로 foreign_keys가 필수

--- a/app/routers/profile.py
+++ b/app/routers/profile.py
@@ -32,24 +32,24 @@ async def get_profiles(db: Session = Depends(get_db)):
     :return: List[user profile]
     """
     users = get_users(db)
-    user_ids = [user.id for user in users]
+    user_ids = [user.social_id for user in users]
     data = []
     for user_id in user_ids:
         data.append(get_user_profile(db, user_id))
     return data
 
 @router.get("/{user_id}", response_model=UserProfileResponse)
-async def get_profile(user_id: int, db: Session = Depends(get_db)):
+async def get_profile(user_id: str, db: Session = Depends(get_db)):
     """
     특정 유저 프로필 정보 조회 API \n
-    :param user_id: \n
+    :param user_id(social_id): \n
     :return: user profile
     """
     profile = get_user_profile(db, user_id)
     return profile
 
 @router.patch("/{user_id}", response_model=UserProfileResponse)
-async def update_profile(user_id : int, profile_update: UserProfileUpdate, token: AuthJWT = Depends(), db: Session = Depends(get_db)):
+async def update_profile(user_id : str, profile_update: UserProfileUpdate, token: AuthJWT = Depends(), db: Session = Depends(get_db)):
     """
     프로필 정보 수정 API \n
     :param 업데이트할 필드의 값: \n
@@ -63,18 +63,18 @@ async def update_profile(user_id : int, profile_update: UserProfileUpdate, token
 def create_profile_view(view: ProfileViewCreate, db: Session = Depends(get_db)):
     """
     프로필 조회 기록 생성 API \n
-    :param 조회한 유저(visitor_id): \n
-    :param 프로필 주인(owner_id): \n
+    :param 조회한 유저(visitor's social_id): \n
+    :param 프로필 주인(owner's social_id): \n
     :return ProfileView object:
     """
     result = create_view(db, view)
     return result
 
 @router.get("/visitors/{user_id}", response_model=List[ProfileViewer])
-def get_visitors(user_id: int, db: Session=Depends(get_db)):
+def get_visitors(user_id: str, db: Session=Depends(get_db)):
     """
     <방문자 기록>용 특정 유저의 프로필 조회한 사람들 정보 반환 API \n
-    :param user_id: \n
+    :param user_id(owner's social_id): \n
     :return List[User]
     """
     return get_visitor_lists(db, user_id)

--- a/app/schemas/profile.py
+++ b/app/schemas/profile.py
@@ -23,6 +23,7 @@ class UserProfileCreate(BaseModel):
         from_attributes = True
 
 class UserProfileResponse(BaseModel):
+    social_id: str = Field(..., description="Kakao's Unique Social ID")         # user의 카카오 social_id
     user_name: str = Field(..., description="Kakao's Profile Name")
     dog_name: str
     dog_gender: str = Field(..., description="남자아이/여자아이")
@@ -69,12 +70,12 @@ class UserProfileAbstract(BaseModel):
     # 한 줄 소개
 
 class ProfileViewCreate(BaseModel):
-    owner_id: int
-    visitor_id: int
+    owner_id: str # social_id
+    visitor_id: str # social_id
 
 # <방문자 기록> 화면에서 보여줄 내용들
 class ProfileViewer(BaseModel):
-    visitor_id: int     # 방문자 고유 ID -> 이를 통해 해당 방문자의 프로필(피드)로 이동할 수 있도록
+    visitor_id: str     # 방문자 social_id
     visitor_name: str   # 방문자 이름
     visitor_image : str # 방문자의 프로필 이미지
     viewed_at : datetime # 정렬을 위해?

--- a/main.py
+++ b/main.py
@@ -19,8 +19,8 @@ class Settings(BaseModel):
     AuthJWT config setting
     """
     authjwt_secret_key: str = os.getenv("JWT_SECRET_KEY", "test_token")
-    authjwt_access_token_expires: int = timedelta(days=1)       # access_token은 1일
-    authjwt_refresh_token_expires: int = timedelta(days=3)      # 3일
+    authjwt_access_token_expires: int = timedelta(days=7)       # 개발을 위해 7일로 늘림
+    authjwt_refresh_token_expires: int = timedelta(days=7)      # 3일
 
 @AuthJWT.load_config
 def get_config():


### PR DESCRIPTION
### 작업 설명
- User쪽 API의 user_id를 User의 고유 ID(int type)이 아니라 Kakao 기반 social_id(string type)으로 대체
- 기존의 프론트 연결에 최대한 덜 영향을 주기 위해 API의 파라미터 등은 건드리지 않음
- 내부 로직만 수정하여 social_id를 'user_id'에 넣어주면 작동하는 방식으로 변경
- 로컬에서 User쪽 모든 API 문제 없이 작동하는 것 확인

### 참고
- profile_views 테이블을 재생성 해야한다(owner_id, visitor_id가 int형에서 str 타입으로 변경되어야 하므로)